### PR TITLE
3.3.3: Fix potential memory leak issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.3.3] - 2024-05-02
+
+### Fixed
+
+- Fixed potential memory leak issues (relating to timer .unref() calls and unresolved promises in background refresh function)
+
 ## [3.3.2] - 2024-05-02
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cryptotaxcalculator/axios-cached-dns-resolve",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cryptotaxcalculator/axios-cached-dns-resolve",
-      "version": "3.3.2",
+      "version": "3.3.3",
       "license": "MIT",
       "dependencies": {
         "json-stringify-safe": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cryptotaxcalculator/axios-cached-dns-resolve",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "files": [
     "dist"
   ],

--- a/src/axios-cached-dns-resolve.ts
+++ b/src/axios-cached-dns-resolve.ts
@@ -201,12 +201,12 @@ export async function backgroundRefresh() {
         config.cache?.set(key, value)
         stats.refreshed += 1
       } catch (err: any) {
-// best effort
+        // best effort
         recordError(err, `Error backgroundRefresh host: ${key}, ${stringify(value)}, ${err.message}`)
       }
     }
   } catch (err: any) {
-// best effort
+    // best effort
     recordError(err, `Error backgroundRefresh, ${err.message}`)
   } finally {
     backgroundRefreshing = false


### PR DESCRIPTION
The package may not be cleaning up timers properly (i.e. background refresh and cache prune).

In addition, there may be unnecessary/unmanaged promises being created in `backgroundRefresh` which can contribute to memory leaks.

This PR fixes this by:
- Cleaning up timers properly (using .unref())
- Changing the async `.forEach()` in `backgroundRefresh` to a for/const loop

Testing
1. Run `npm install` to install dependencies
2. Run `npm run build` to verify that it builds
3. Run `npm test` (or `npx jest src --detectOpenHandles) to verify that tests pass and there are no open handles at the end of tests