### PR TITLE
Feature: Add the option to use a Redis cache

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,7 +1,8 @@
 module.exports = {
-  extends: 'airbnb-base',
-  plugins: [
-    'import',
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint', 'import'],
+  extends: [
+    'plugin:@typescript-eslint/recommended',
   ],
   rules: {
     'import/extensions': 0,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.4.0] - 2024-05-20
+
+### Added
+
+- Added option to use Redis as cache (instead of just `lru-cache`)
+
 ## [3.3.3] - 2024-05-02
 
 ### Fixed
@@ -32,13 +38,11 @@
 
 - Merged community PR (thanks matrec4) 'Adding a .d.ts file to declare the module for tsnode' [#29](https://github.com/tcollinsworth/axios-cached-dns-resolve/pull/29)
 
-
 ## [3.2.1] - 2022-09-06
 
 ### Fixed
 
 - Fixed bug were getDnsCacheEntries was returning generator from lru-cache to instead return array
-
 
 ## [3.2.0] - 2022-09-06
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.3.3",
       "license": "MIT",
       "dependencies": {
+        "ioredis": "^5.4.1",
         "json-stringify-safe": "^5.0.1",
         "lru-cache": "^7.18.3",
         "pino": "^8.14.1",
@@ -763,6 +764,11 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "dev": true
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -2223,6 +2229,14 @@
       "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==",
       "dev": true
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2386,7 +2400,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2402,8 +2415,7 @@
     "node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/dedent": {
       "version": "1.5.3",
@@ -2469,6 +2481,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -4031,6 +4051,29 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.4.1.tgz",
+      "integrity": "sha512-2YZsvl7jopIa1gaePkeMtd9rAcSjOOjPtpcLlOeusyO+XH2SK5ZcT+UCrElPP+WVIInh2TzeI4XW9ENaSLVVHA==",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -5233,6 +5276,16 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+    },
     "node_modules/lodash.isempty": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
@@ -6059,6 +6112,25 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
@@ -6401,6 +6473,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/statuses": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cryptotaxcalculator/axios-cached-dns-resolve",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cryptotaxcalculator/axios-cached-dns-resolve",
-      "version": "3.3.3",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "ioredis": "^5.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "@types/jest": "^29.5.12",
         "@types/json-stringify-safe": "^5.0.3",
         "@types/node": "^20.12.7",
+        "@typescript-eslint/eslint-plugin": "^7.9.0",
+        "@typescript-eslint/parser": "^7.9.0",
         "axios": "^0.28.0",
         "body-parser": "^1.20.2",
         "delay": "^5.0.0",
@@ -671,18 +673,18 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
-      "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -721,22 +723,22 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
-      "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "^4.1.1",
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
       "engines": {
@@ -757,9 +759,9 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "dev": true
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -1341,6 +1343,221 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.9.0.tgz",
+      "integrity": "sha512-6e+X0X3sFe/G/54aC3jt0txuMTURqLyekmEHViqyA2VnxhLMpvA6nqmcjIy+Cr9tLDHPssA74BP5Mx9HQIxBEA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.9.0",
+        "@typescript-eslint/type-utils": "7.9.0",
+        "@typescript-eslint/utils": "7.9.0",
+        "@typescript-eslint/visitor-keys": "7.9.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.9.0.tgz",
+      "integrity": "sha512-qHMJfkL5qvgQB2aLvhUSXxbK7OLnDkwPzFalg458pxQgfxKDfT1ZDbHQM/I6mDIf/svlMkj21kzKuQ2ixJlatQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.9.0",
+        "@typescript-eslint/types": "7.9.0",
+        "@typescript-eslint/typescript-estree": "7.9.0",
+        "@typescript-eslint/visitor-keys": "7.9.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.9.0.tgz",
+      "integrity": "sha512-ZwPK4DeCDxr3GJltRz5iZejPFAAr4Wk3+2WIBaj1L5PYK5RgxExu/Y68FFVclN0y6GGwH8q+KgKRCvaTmFBbgQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.9.0",
+        "@typescript-eslint/visitor-keys": "7.9.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.9.0.tgz",
+      "integrity": "sha512-6Qy8dfut0PFrFRAZsGzuLoM4hre4gjzWJB6sUvdunCYZsYemTkzZNwF1rnGea326PHPT3zn5Lmg32M/xfJfByA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "7.9.0",
+        "@typescript-eslint/utils": "7.9.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.9.0.tgz",
+      "integrity": "sha512-oZQD9HEWQanl9UfsbGVcZ2cGaR0YT5476xfWE0oE5kQa2sNK2frxOlkeacLOTh9po4AlUT5rtkGyYM5kew0z5w==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.9.0.tgz",
+      "integrity": "sha512-zBCMCkrb2YjpKV3LA0ZJubtKCDxLttxfdGmwZvTqqWevUPN0FZvSI26FalGFFUZU/9YQK/A4xcQF9o/VVaCKAg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.9.0",
+        "@typescript-eslint/visitor-keys": "7.9.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.9.0.tgz",
+      "integrity": "sha512-5KVRQCzZajmT4Ep+NEgjXCvjuypVvYHUW7RHlXzNPuak2oWpVoD1jf5xCP0dPAuNIchjC7uQyvbdaSTFaLqSdA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.9.0",
+        "@typescript-eslint/types": "7.9.0",
+        "@typescript-eslint/typescript-estree": "7.9.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.9.0.tgz",
+      "integrity": "sha512-iESPx2TNLDNGQLyjKhUvIKprlP49XNEK+MvIf9nIO7ZZaZdbnfWKHnXAgufpxqfA0YryH8XToi4+CjBgVnFTSQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.9.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -1366,9 +1583,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1508,6 +1725,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/array.prototype.flat": {
@@ -2157,9 +2383,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -2280,6 +2506,18 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/doctrine": {
@@ -2454,27 +2692,28 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.44.0.tgz",
-      "integrity": "sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.1.0",
-        "@eslint/js": "8.44.0",
-        "@humanwhocodes/config-array": "^0.11.10",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.1",
-        "espree": "^9.6.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -2484,7 +2723,6 @@
         "globals": "^13.19.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
@@ -2496,7 +2734,6 @@
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
       },
       "bin": {
@@ -2643,9 +2880,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -2659,9 +2896,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2792,9 +3029,9 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
-      "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.9.0",
@@ -3074,6 +3311,22 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3420,9 +3673,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -3447,6 +3700,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -3663,9 +3936,9 @@
       ]
     },
     "node_modules/ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -5040,6 +5313,15 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -5401,6 +5683,15 @@
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
       "dev": true
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -5641,9 +5932,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -5932,27 +6223,12 @@
       "integrity": "sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg=="
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -6363,6 +6639,18 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
     "node_modules/ts-jest": {
       "version": "29.1.2",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.2.tgz",
@@ -6747,12 +7035,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cryptotaxcalculator/axios-cached-dns-resolve",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
+    "ioredis": "^5.4.1",
     "json-stringify-safe": "^5.0.1",
     "lru-cache": "^7.18.3",
     "pino": "^8.14.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "@types/jest": "^29.5.12",
     "@types/json-stringify-safe": "^5.0.3",
     "@types/node": "^20.12.7",
+    "@typescript-eslint/eslint-plugin": "^7.9.0",
+    "@typescript-eslint/parser": "^7.9.0",
     "axios": "^0.28.0",
     "body-parser": "^1.20.2",
     "delay": "^5.0.0",

--- a/src/DNSEntryCache.ts
+++ b/src/DNSEntryCache.ts
@@ -1,0 +1,108 @@
+import Redis from "ioredis";
+import stringify from "json-stringify-safe";
+import LRUCache from "lru-cache";
+import { config } from "./axios-cached-dns-resolve";
+import { CacheInterface, Config, DnsEntry } from "./index.d";
+
+export class DNSEntryCache implements CacheInterface {
+  private lruCache?: LRUCache<string, DnsEntry>;
+  private redisCache?: Redis;
+  public size: number = 0;
+
+  constructor(config: Config, fresh?: boolean) {
+    if (config.redisConfig) {
+      // Initialize Redis cache
+      this.redisCache = new Redis(config.redisConfig.url, {
+        password: config.redisConfig.password,
+      });
+
+      // If fresh is true, clear the cache
+      if (fresh) {
+        this.clear();
+      }
+    } else if (config.lruCacheConfig) {
+      // Initialize LRU cache
+      this.lruCache = new LRUCache<string, DnsEntry>(config.lruCacheConfig);
+    } else {
+      // Default to LRU cache
+      this.lruCache = new LRUCache<string, DnsEntry>({
+        max: 500,
+        ttl: 1000,
+      });
+    }
+  }
+
+  async get(key: string): Promise<DnsEntry | null> {
+    if (this.redisCache) {
+      const entry = await this.redisCache.get(key);
+      return entry ? JSON.parse(entry) : null;
+    } else if (this.lruCache) {
+      return this.lruCache.get(key) || null;
+    }
+    return null;
+  }
+
+  async set(key: string, value: DnsEntry): Promise<void> {
+    const isNewEntry = this.redisCache
+      ? !(await this.redisCache.exists(key))
+      : !this.lruCache?.has(key);
+    if (this.redisCache) {
+      await this.redisCache.setex(
+        key,
+        config.redisConfig?.ttl || 5,
+        stringify(value)
+      );
+    } else if (this.lruCache) {
+      this.lruCache.set(key, value);
+    }
+    if (isNewEntry) {
+      this.size++;
+    }
+  }
+
+  async entries(): Promise<DnsEntry[]> {
+    if (this.redisCache) {
+      const keys = await this.redisCache.keys("*");
+      return Promise.all(keys.map(async (key) => this.get(key))).then(
+        (entries) =>
+          entries.filter(
+            (entry): entry is DnsEntry => entry !== null
+          ) as DnsEntry[]
+      );
+    } else if (this.lruCache) {
+      return Array.from(this.lruCache.entries()).map((entry) => entry[1]);
+    }
+    return [];
+  }
+
+  async purgeStale(): Promise<void> {
+    if (this.redisCache) {
+      // Redis does not need manual purging if 'EX' is set
+    } else if (this.lruCache) {
+      this.lruCache.purgeStale();
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    const exists = this.redisCache
+      ? await this.redisCache.exists(key)
+      : this.lruCache?.has(key);
+    if (this.redisCache) {
+      await this.redisCache.del(key);
+    } else if (this.lruCache) {
+      this.lruCache.delete(key);
+    }
+    if (exists) {
+      this.size--;
+    }
+  }
+
+  async clear(): Promise<void> {
+    if (this.redisCache) {
+      await this.redisCache.flushall();
+    } else if (this.lruCache) {
+      this.lruCache.clear();
+    }
+    this.size = 0;
+  }
+}

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,25 +1,43 @@
-import delay from "delay";
-import LRUCache from "lru-cache";
 import axios, { AxiosInstance } from "axios";
+import delay from "delay";
 import * as axiosCachingDns from "..";
+import { DNSEntryCache } from "../DNSEntryCache";
 
 let axiosClient: AxiosInstance;
+let useRedis: boolean = false; // Flag to switch between Redis and LRU
 
-beforeEach(() => {
+beforeEach(async () => {
   axiosCachingDns.config.dnsTtlMs = 1000;
   axiosCachingDns.config.dnsIdleTtlMs = 5000;
   axiosCachingDns.config.cacheGraceExpireMultiplier = 2;
   axiosCachingDns.config.backgroundScanMs = 100;
 
-  axiosCachingDns.cacheConfig.ttl =
-    axiosCachingDns.config.dnsTtlMs *
-    axiosCachingDns.config.cacheGraceExpireMultiplier;
+  if (useRedis) {
+    axiosCachingDns.config.redisConfig = {
+      url: "localhost:6379",
+      ttl:
+        (axiosCachingDns.config.dnsTtlMs *
+          axiosCachingDns.config.cacheGraceExpireMultiplier) /
+        1000,
+    };
+    axiosCachingDns.config.lruCacheConfig = undefined;
+  } else {
+    axiosCachingDns.config.lruCacheConfig = {
+      max: axiosCachingDns.config.dnsCacheSize,
+      ttl:
+        axiosCachingDns.config.dnsTtlMs *
+        axiosCachingDns.config.cacheGraceExpireMultiplier, // grace for refresh
+    };
+    axiosCachingDns.config.redisConfig = undefined;
+  }
 
-  axiosCachingDns.config.cache = new LRUCache(axiosCachingDns.cacheConfig);
+  axiosCachingDns.config.cache = new DNSEntryCache(
+    axiosCachingDns.config,
+    true // Create a fresh cache on each run
+  );
 
   axiosClient = axios.create({
     timeout: 5000,
-    // maxRedirects: 0,
   });
 
   axiosCachingDns.registerInterceptor(axiosClient);
@@ -33,168 +51,200 @@ afterAll(() => {
   axiosCachingDns.reset();
 });
 
-test("query google with baseURL and relative url", async () => {
-  axiosCachingDns.registerInterceptor(axios);
-
-  const { data } = await axios.get("/finance", {
-    baseURL: "http://www.google.com",
-    // headers: { Authorization: `Basic ${basicauth}` },
+describe("LRU Cache Tests", () => {
+  beforeAll(async () => {
+    useRedis = false;
+    await clearStats();
   });
-  expect(data).toBeTruthy();
-  expect(axiosCachingDns.getStats().dnsEntries).toBe(1);
-  expect(axiosCachingDns.getStats().misses).toBe(1);
 
-  const dnsCacheEntries = axiosCachingDns.getDnsCacheEntries();
-  expect(Array.isArray(dnsCacheEntries)).toBeTruthy();
-  expect(Array.isArray(dnsCacheEntries[0].ips)).toBeTruthy();
-  expect(dnsCacheEntries[0].ips[0]).toBeTruthy();
-  expect(dnsCacheEntries[0].host).toBeTruthy();
-  expect(dnsCacheEntries[0].lastUsedTs).toBeTruthy();
-  expect(dnsCacheEntries[0].updatedTs).toBeTruthy();
+  runTests();
 });
 
-test("query google caches and after idle delay uncached", async () => {
-  const resp = await axiosClient.get("http://google.com");
-  expect(resp.data).toBeTruthy();
-  expect(axiosCachingDns.config.cache?.get("google.com")).toBeTruthy();
-  await delay(6000);
-  expect(axiosCachingDns.config.cache?.get("google.com")).toBeFalsy();
+describe("Redis Cache Tests", () => {
+  beforeAll(() => {
+    useRedis = true;
+    clearStats();
+  });
 
-  const expectedStats = {
-    dnsEntries: 0,
-    refreshed: 0,
-    hits: 0,
-    misses: 2,
-    idleExpired: 1,
-    errors: 0,
-    lastError: 0,
-    lastErrorTs: 0,
-  };
+  runTests();
+});
 
-  const stats = axiosCachingDns.getStats();
+function runTests() {
+  test("query google with baseURL and relative url", async () => {
+    axiosCachingDns.registerInterceptor(axios);
+
+    const { data } = await axios.get("/finance", {
+      baseURL: "http://www.google.com",
+      // headers: { Authorization: `Basic ${basicauth}` },
+    });
+    expect(data).toBeTruthy();
+    expect((await axiosCachingDns.getStats()).dnsEntries).toBe(1);
+    expect((await axiosCachingDns.getStats()).misses).toBe(1);
+
+    const dnsCacheEntries = await axiosCachingDns.getDnsCacheEntries();
+    expect(Array.isArray(dnsCacheEntries)).toBeTruthy();
+    expect(Array.isArray(dnsCacheEntries[0].ips)).toBeTruthy();
+    expect(dnsCacheEntries[0].ips[0]).toBeTruthy();
+    expect(dnsCacheEntries[0].host).toBeTruthy();
+    expect(dnsCacheEntries[0].lastUsedTs).toBeTruthy();
+    expect(dnsCacheEntries[0].updatedTs).toBeTruthy();
+  });
+
+  test("query google caches and after idle delay uncached", async () => {
+    const resp = await axiosClient.get("http://google.com");
+    expect(resp.data).toBeTruthy();
+    expect(await axiosCachingDns.config.cache?.get("google.com")).toBeTruthy();
+    await delay(6000);
+    expect(await axiosCachingDns.config.cache?.get("google.com")).toBeFalsy();
+
+    const expectedStats = {
+      dnsEntries: 0,
+      refreshed: 0,
+      hits: 0,
+      misses: 2,
+      idleExpired: 1,
+      errors: 0,
+      lastError: 0,
+      lastErrorTs: 0,
+    };
+
+    const stats = await axiosCachingDns.getStats();
+    stats.refreshed = 0;
+    expect(stats).toEqual(expectedStats);
+  });
+
+  test("query google caches and refreshes", async () => {
+    await axiosClient.get("http://google.com");
+    const dnsEntry = await axiosCachingDns.config.cache?.get("google.com");
+    if (!dnsEntry) throw new Error("DNS entry for google.com not found");
+    const { updatedTs } = dnsEntry;
+    const timeoutTime = Date.now() + 5000;
+    while (true) {
+      const dnsEntry = await axiosCachingDns.config.cache?.get("google.com");
+      if (!dnsEntry) throw new Error("dnsEntry missing or expired");
+      if (updatedTs !== dnsEntry.updatedTs) break;
+      if (Date.now() > timeoutTime) throw new Error("Timeout exceeded");
+      await delay(10);
+    }
+
+    const expectedStats = {
+      dnsEntries: 1,
+      refreshed: 0,
+      hits: 0,
+      misses: 3,
+      idleExpired: 1,
+      errors: 0,
+      lastError: 0,
+      lastErrorTs: 0,
+    };
+
+    const stats = await axiosCachingDns.getStats();
+    stats.refreshed = 0;
+    expect(stats).toEqual(expectedStats);
+  });
+
+  test("query two services, caches and after one idle delay uncached", async () => {
+    await axiosClient.get("http://amazon.com");
+
+    await axiosClient.get("http://microsoft.com");
+    const dnsEntry = await axiosCachingDns.config.cache?.get("microsoft.com");
+    if (!dnsEntry) throw new Error("DNS entry for microsoft.com not found");
+    const { lastUsedTs } = dnsEntry;
+    expect(dnsEntry.nextIdx).toBe(1);
+
+    await axiosClient.get("http://microsoft.com");
+    const dnsEntry2 = await axiosCachingDns.config.cache?.get("microsoft.com");
+    if (!dnsEntry2) throw new Error("DNS entry for microsoft.com not found");
+    expect(dnsEntry2.nextIdx).toBe(2);
+
+    expect(lastUsedTs < dnsEntry2.lastUsedTs).toBeTruthy();
+
+    expect(axiosCachingDns.config.cache?.size).toBe(2);
+    await axiosClient.get("http://microsoft.com");
+    const dnsEntry3 = await axiosCachingDns.config.cache?.get("microsoft.com");
+    if (!dnsEntry3) throw new Error("DNS entry for microsoft.com not found");
+    expect(dnsEntry3.nextIdx).toBe(3);
+
+    expect(lastUsedTs !== dnsEntry3.lastUsedTs).toBeTruthy();
+
+    expect(axiosCachingDns.config.cache?.size).toBe(2);
+    await delay(4000);
+    expect(axiosCachingDns.config.cache?.size).toBe(1);
+    await delay(2000);
+    expect(axiosCachingDns.config.cache?.size).toBe(0);
+
+    const expectedStats = {
+      dnsEntries: 0,
+      refreshed: 0,
+      hits: 2,
+      misses: 5,
+      idleExpired: 3,
+      errors: 0,
+      lastError: 0,
+      lastErrorTs: 0,
+    };
+
+    const stats = await axiosCachingDns.getStats();
+    stats.refreshed = 0;
+    expect(stats).toEqual(expectedStats);
+  });
+
+  test("validate axios config not altered", async () => {
+    const baseURL = "http://microsoft.com";
+    const axiosConfig = { baseURL };
+    const custAxiosClient = axios.create(axiosConfig);
+
+    axiosCachingDns.registerInterceptor(custAxiosClient);
+
+    await custAxiosClient.get("/");
+    expect(baseURL).toBe(axiosConfig.baseURL);
+    await custAxiosClient.get("/");
+    expect(baseURL).toBe(axiosConfig.baseURL);
+  });
+
+  test("validate axios get config not altered", async () => {
+    const url = "http://microsoft.com";
+    const custAxiosClient = axios.create();
+
+    const reqConfig = {
+      method: "get",
+      url,
+    };
+
+    axiosCachingDns.registerInterceptor(custAxiosClient);
+
+    await custAxiosClient.get(url, reqConfig);
+    expect(url).toBe(reqConfig.url);
+    await custAxiosClient.get(url, reqConfig);
+    expect(url).toBe(reqConfig.url);
+  });
+
+  test("validate axios request config not altered", async () => {
+    const url = "http://microsoft.com";
+    const custAxiosClient = axios.create();
+
+    const reqConfig = {
+      method: "get",
+      url,
+    };
+
+    axiosCachingDns.registerInterceptor(custAxiosClient);
+
+    await custAxiosClient.request(reqConfig);
+    expect(url).toBe(reqConfig.url);
+    await custAxiosClient.request(reqConfig);
+    expect(url).toBe(reqConfig.url);
+  });
+}
+
+async function clearStats() {
+  const stats = await axiosCachingDns.getStats();
+  stats.dnsEntries = 0;
   stats.refreshed = 0;
-  expect(stats).toEqual(expectedStats);
-});
-
-test("query google caches and refreshes", async () => {
-  await axiosClient.get("http://google.com");
-  const dnsEntry = axiosCachingDns.config.cache?.get("google.com");
-  if (!dnsEntry) throw new Error("DNS entry for google.com not found");
-  const { updatedTs } = dnsEntry;
-  const timeoutTime = Date.now() + 5000;
-  while (true) {
-    const dnsEntry = axiosCachingDns.config.cache?.get("google.com");
-    if (!dnsEntry) throw new Error("dnsEntry missing or expired");
-    if (updatedTs !== dnsEntry.updatedTs) break;
-    if (Date.now() > timeoutTime) throw new Error("Timeout exceeded");
-    await delay(10);
-  }
-
-  const expectedStats = {
-    dnsEntries: 1,
-    refreshed: 0,
-    hits: 0,
-    misses: 3,
-    idleExpired: 1,
-    errors: 0,
-    lastError: 0,
-    lastErrorTs: 0,
-  };
-
-  const stats = axiosCachingDns.getStats();
-  stats.refreshed = 0;
-  expect(stats).toEqual(expectedStats);
-});
-
-test("query two services, caches and after one idle delay uncached", async () => {
-  await axiosClient.get("http://amazon.com");
-
-  await axiosClient.get("http://microsoft.com");
-  const dnsEntry = axiosCachingDns.config.cache?.get("microsoft.com");
-  if (!dnsEntry) throw new Error("DNS entry for microsoft.com not found");
-  const { lastUsedTs } = dnsEntry;
-  expect(dnsEntry.nextIdx).toBe(1);
-
-  await axiosClient.get("http://microsoft.com");
-  const dnsEntry2 = axiosCachingDns.config.cache?.get("microsoft.com");
-  if (!dnsEntry2) throw new Error("DNS entry for microsoft.com not found");
-  expect(dnsEntry2.nextIdx).toBe(2);
-
-  expect(lastUsedTs < dnsEntry2.lastUsedTs).toBeTruthy();
-
-  expect(axiosCachingDns.config.cache?.size).toBe(2);
-  await axiosClient.get("http://microsoft.com");
-  const dnsEntry3 = axiosCachingDns.config.cache?.get("microsoft.com");
-  if (!dnsEntry3) throw new Error("DNS entry for microsoft.com not found");
-  expect(dnsEntry3.nextIdx).toBe(3);
-
-  expect(lastUsedTs !== dnsEntry3.lastUsedTs).toBeTruthy();
-
-  expect(axiosCachingDns.config.cache?.size).toBe(2);
-  await delay(4000);
-  expect(axiosCachingDns.config.cache?.size).toBe(1);
-  await delay(2000);
-  expect(axiosCachingDns.config.cache?.size).toBe(0);
-
-  const expectedStats = {
-    dnsEntries: 0,
-    refreshed: 0,
-    hits: 2,
-    misses: 5,
-    idleExpired: 3,
-    errors: 0,
-    lastError: 0,
-    lastErrorTs: 0,
-  };
-
-  const stats = axiosCachingDns.getStats();
-  stats.refreshed = 0;
-  expect(stats).toEqual(expectedStats);
-});
-
-test("validate axios config not altered", async () => {
-  const baseURL = "http://microsoft.com";
-  const axiosConfig = { baseURL };
-  const custAxiosClient = axios.create(axiosConfig);
-
-  axiosCachingDns.registerInterceptor(custAxiosClient);
-
-  await custAxiosClient.get("/");
-  expect(baseURL).toBe(axiosConfig.baseURL);
-  await custAxiosClient.get("/");
-  expect(baseURL).toBe(axiosConfig.baseURL);
-});
-
-test("validate axios get config not altered", async () => {
-  const url = "http://microsoft.com";
-  const custAxiosClient = axios.create();
-
-  const reqConfig = {
-    method: "get",
-    url,
-  };
-
-  axiosCachingDns.registerInterceptor(custAxiosClient);
-
-  await custAxiosClient.get(url, reqConfig);
-  expect(url).toBe(reqConfig.url);
-  await custAxiosClient.get(url, reqConfig);
-  expect(url).toBe(reqConfig.url);
-});
-
-test("validate axios request config not altered", async () => {
-  const url = "http://microsoft.com";
-  const custAxiosClient = axios.create();
-
-  const reqConfig = {
-    method: "get",
-    url,
-  };
-
-  axiosCachingDns.registerInterceptor(custAxiosClient);
-
-  await custAxiosClient.request(reqConfig);
-  expect(url).toBe(reqConfig.url);
-  await custAxiosClient.request(reqConfig);
-  expect(url).toBe(reqConfig.url);
-});
+  stats.hits = 0;
+  stats.misses = 0;
+  stats.idleExpired = 0;
+  stats.errors = 0;
+  stats.lastError = 0;
+  stats.lastErrorTs = 0;
+}

--- a/src/axios-cached-dns-resolve.ts
+++ b/src/axios-cached-dns-resolve.ts
@@ -1,43 +1,48 @@
-import dns from 'dns'
-import URL from 'url'
-import net from 'net'
-import stringify from 'json-stringify-safe'
-import LRUCache from 'lru-cache'
-import util from 'util'
-import { init as initLogger } from './logging'
-import { Logger } from 'pino'
-import { AxiosInstance } from 'axios'
-import { Config, CacheConfig, Stats, DnsEntry } from "./index.d";
+import { AxiosInstance } from "axios";
+import dns from "dns";
+import stringify from "json-stringify-safe";
+import LRUCache from "lru-cache";
+import net from "net";
+import { Logger } from "pino";
+import URL from "url";
+import util from "util";
+import { CacheConfig, Config, DnsEntry, Stats } from "./index.d";
+import { init as initLogger } from "./logging";
 
-const dnsResolve = util.promisify(dns.resolve)
-const dnsLookup = util.promisify(dns.lookup)
+const dnsResolve = util.promisify(dns.resolve);
+const dnsLookup = util.promisify(dns.lookup);
 
 export const config = {
-  disabled: process.env.AXIOS_DNS_DISABLE === 'true',
-  dnsTtlMs: parseInt(process.env.AXIOS_DNS_CACHE_TTL_MS || '5000'), // when to refresh actively used dns entries (5 sec)
-  cacheGraceExpireMultiplier: parseInt(process.env.AXIOS_DNS_CACHE_EXPIRE_MULTIPLIER || '2'), // maximum grace to use entry beyond TTL
-  dnsIdleTtlMs: parseInt(process.env.AXIOS_DNS_CACHE_IDLE_TTL_MS || '1000') * 60 * 60, // when to remove entry entirely if not being used (1 hour)
-  backgroundScanMs: parseInt(process.env.AXIOS_DNS_BACKGROUND_SCAN_MS || '2400'), // how frequently to scan for expired TTL and refresh (2.4 sec)
-  dnsCacheSize: parseInt(process.env.AXIOS_DNS_CACHE_SIZE || '100'), // maximum number of entries to keep in cache
+  disabled: process.env.AXIOS_DNS_DISABLE === "true",
+  dnsTtlMs: parseInt(process.env.AXIOS_DNS_CACHE_TTL_MS || "5000"), // when to refresh actively used dns entries (5 sec)
+  cacheGraceExpireMultiplier: parseInt(
+    process.env.AXIOS_DNS_CACHE_EXPIRE_MULTIPLIER || "2"
+  ), // maximum grace to use entry beyond TTL
+  dnsIdleTtlMs:
+    parseInt(process.env.AXIOS_DNS_CACHE_IDLE_TTL_MS || "1000") * 60 * 60, // when to remove entry entirely if not being used (1 hour)
+  backgroundScanMs: parseInt(
+    process.env.AXIOS_DNS_BACKGROUND_SCAN_MS || "2400"
+  ), // how frequently to scan for expired TTL and refresh (2.4 sec)
+  dnsCacheSize: parseInt(process.env.AXIOS_DNS_CACHE_SIZE || "100"), // maximum number of entries to keep in cache
   // pino logging options
   logging: {
-    name: 'axios-cache-dns-resolve',
+    name: "axios-cache-dns-resolve",
     // enabled: true,
-    level: process.env.AXIOS_DNS_LOG_LEVEL || 'info', // default 'info' others trace, debug, info, warn, error, and fatal
+    level: process.env.AXIOS_DNS_LOG_LEVEL || "info", // default 'info' others trace, debug, info, warn, error, and fatal
     // timestamp: true,
-    prettyPrint: process.env.NODE_ENV === 'DEBUG' || false,
+    prettyPrint: process.env.NODE_ENV === "DEBUG" || false,
     formatters: {
-      level(label: string, number: number) {
-        return { level: label }
+      level: (label: string) => {
+        return { level: label };
       },
     },
   },
-  cache: undefined as LRUCache<string, any> | undefined,
+  cache: undefined as LRUCache<string, DnsEntry> | undefined,
 } as Config;
 
 export const cacheConfig = {
   max: config.dnsCacheSize,
-  ttl: (config.dnsTtlMs * config.cacheGraceExpireMultiplier), // grace for refresh
+  ttl: config.dnsTtlMs * config.cacheGraceExpireMultiplier, // grace for refresh
 } as CacheConfig;
 
 export const stats = {
@@ -51,59 +56,62 @@ export const stats = {
   lastErrorTs: 0,
 } as Stats;
 
-let log: Logger
-let backgroundRefreshId: NodeJS.Timeout
-let cachePruneId: NodeJS.Timeout
+let log: Logger;
+let backgroundRefreshId: NodeJS.Timeout;
+let cachePruneId: NodeJS.Timeout;
 
-init()
+init();
 
 export function init() {
-  log = initLogger(config.logging)
+  log = initLogger(config.logging);
 
-  if (config.cache) return
+  if (config.cache) return;
 
-  config.cache = new LRUCache<string, any>(cacheConfig)
+  config.cache = new LRUCache<string, DnsEntry>(cacheConfig);
 
-  startBackgroundRefresh()
-  startPeriodicCachePrune()
+  startBackgroundRefresh();
+  startPeriodicCachePrune();
 }
 
 export function reset() {
   if (backgroundRefreshId) {
-    clearInterval(backgroundRefreshId)
+    clearInterval(backgroundRefreshId);
     backgroundRefreshId.unref();
   }
   if (cachePruneId) {
-    clearInterval(cachePruneId)
+    clearInterval(cachePruneId);
     cachePruneId.unref();
   }
 }
 
 export function startBackgroundRefresh() {
   if (backgroundRefreshId) {
-    clearInterval(backgroundRefreshId)
-    backgroundRefreshId.unref()
+    clearInterval(backgroundRefreshId);
+    backgroundRefreshId.unref();
   }
 
-  backgroundRefreshId = setInterval(backgroundRefresh, config.backgroundScanMs)
+  backgroundRefreshId = setInterval(backgroundRefresh, config.backgroundScanMs);
 }
 
 export function startPeriodicCachePrune() {
   if (cachePruneId) {
-    clearInterval(cachePruneId)
-    cachePruneId.unref()
+    clearInterval(cachePruneId);
+    cachePruneId.unref();
   }
 
-  cachePruneId = setInterval(() => config.cache?.purgeStale(), config.dnsIdleTtlMs)
+  cachePruneId = setInterval(
+    () => config.cache?.purgeStale(),
+    config.dnsIdleTtlMs
+  );
 }
 
 export function getStats() {
-  stats.dnsEntries = config.cache?.size || 0
-  return stats
+  stats.dnsEntries = config.cache?.size || 0;
+  return stats;
 }
 
 export function getDnsCacheEntries() {
-  return Array.from(config.cache?.values() || [])
+  return Array.from(config.cache?.values() || []);
 }
 
 // const dnsEntry = {
@@ -119,71 +127,76 @@ export function getDnsCacheEntries() {
 // }
 
 export function registerInterceptor(axios: AxiosInstance) {
-  if (config.disabled || !axios || !axios.interceptors) return // supertest
+  if (config.disabled || !axios || !axios.interceptors) return; // supertest
   axios.interceptors.request.use(async (reqConfig) => {
     try {
       if (!reqConfig.headers) {
         reqConfig.headers = {};
       }
 
-      let url
+      let url;
       if (reqConfig.baseURL) {
-        url = URL.parse(reqConfig.baseURL)
+        url = URL.parse(reqConfig.baseURL);
       } else {
-        url = URL.parse(reqConfig.url || '')
+        url = URL.parse(reqConfig.url || "");
       }
 
-      if (net.isIP(url.hostname || '')) return reqConfig // skip
+      if (net.isIP(url.hostname || "")) return reqConfig; // skip
 
-      reqConfig.headers.Host = url.hostname || '' // set hostname in header
+      reqConfig.headers.Host = url.hostname || ""; // set hostname in header
 
-      url.hostname = await getAddress(url.hostname || '')
-      url.host = null // clear hostname
+      url.hostname = await getAddress(url.hostname || "");
+      url.host = null; // clear hostname
 
       if (reqConfig.baseURL) {
-        reqConfig.baseURL = URL.format(url)
+        reqConfig.baseURL = URL.format(url);
       } else {
-        reqConfig.url = URL.format(url)
+        reqConfig.url = URL.format(url);
       }
-    } catch (err: any) {
-      recordError(err, `Error getAddress, ${err.message}`)
+    } catch (err) {
+      recordError(
+        err,
+        `Error getAddress, ${
+          err instanceof Error ? err.message : "an unknown error occurred"
+        }`
+      );
     }
 
-    return reqConfig
-  })
+    return reqConfig;
+  });
 }
 
 export async function getAddress(host: string) {
-  let dnsEntry = config.cache?.get(host)
+  let dnsEntry = config.cache?.get(host);
   if (dnsEntry) {
-    stats.hits += 1
-    dnsEntry.lastUsedTs = Date.now()
+    stats.hits += 1;
+    dnsEntry.lastUsedTs = Date.now();
     // eslint-disable-next-line no-plusplus
-    const ip = dnsEntry.ips[dnsEntry.nextIdx++ % dnsEntry.ips.length] // round-robin
-    config.cache?.set(host, dnsEntry)
-    return ip
+    const ip = dnsEntry.ips[dnsEntry.nextIdx++ % dnsEntry.ips.length]; // round-robin
+    config.cache?.set(host, dnsEntry);
+    return ip;
   }
-  stats.misses += 1
-  if (log.isLevelEnabled('debug')) log.debug(`cache miss ${host}`)
+  stats.misses += 1;
+  if (log.isLevelEnabled("debug")) log.debug(`cache miss ${host}`);
 
-  const ips = await resolve(host)
+  const ips = await resolve(host);
   dnsEntry = {
     host,
     ips,
     nextIdx: 0,
     lastUsedTs: Date.now(),
     updatedTs: Date.now(),
-  } as DnsEntry
+  } as DnsEntry;
   // eslint-disable-next-line no-plusplus
-  const ip = dnsEntry.ips[dnsEntry.nextIdx++ % dnsEntry.ips.length] // round-robin
-  config.cache?.set(host, dnsEntry)
-  return ip
+  const ip = dnsEntry.ips[dnsEntry.nextIdx++ % dnsEntry.ips.length]; // round-robin
+  config.cache?.set(host, dnsEntry);
+  return ip;
 }
 
-let backgroundRefreshing = false
+let backgroundRefreshing = false;
 export async function backgroundRefresh() {
-  if (backgroundRefreshing) return // don't start again if currently iterating slowly
-  backgroundRefreshing = true
+  if (backgroundRefreshing) return; // don't start again if currently iterating slowly
+  backgroundRefreshing = true;
   try {
     for (const [key, value] of config.cache?.entries() || []) {
       try {
@@ -191,25 +204,35 @@ export async function backgroundRefresh() {
           continue; // skip
         }
         if (value.lastUsedTs + config.dnsIdleTtlMs <= Date.now()) {
-          stats.idleExpired += 1
-          config.cache?.delete(key)
+          stats.idleExpired += 1;
+          config.cache?.delete(key);
           continue;
         }
-        const ips = await resolve(value.host)
-        value.ips = ips
-        value.updatedTs = Date.now()
-        config.cache?.set(key, value)
-        stats.refreshed += 1
-      } catch (err: any) {
+        const ips = await resolve(value.host);
+        value.ips = ips;
+        value.updatedTs = Date.now();
+        config.cache?.set(key, value);
+        stats.refreshed += 1;
+      } catch (err) {
         // best effort
-        recordError(err, `Error backgroundRefresh host: ${key}, ${stringify(value)}, ${err.message}`)
+        recordError(
+          err,
+          `Error backgroundRefresh host: ${key}, ${stringify(value)}, ${
+            err instanceof Error ? err.message : "an unknown error occurred"
+          }`
+        );
       }
     }
-  } catch (err: any) {
+  } catch (err) {
     // best effort
-    recordError(err, `Error backgroundRefresh, ${err.message}`)
+    recordError(
+      err,
+      `Error backgroundRefresh, ${
+        err instanceof Error ? err.message : "an unknown error occurred"
+      }`
+    );
   } finally {
-    backgroundRefreshing = false
+    backgroundRefreshing = false;
   }
 }
 
@@ -219,30 +242,32 @@ export async function backgroundRefresh() {
  * @returns {*[]}
  */
 async function resolve(host: string) {
-  let ips
+  let ips;
   try {
-    ips = await dnsResolve(host)
+    ips = await dnsResolve(host);
   } catch (e) {
-    let lookupResp = await dnsLookup(host, { all: true }) // pass options all: true for all addresses
-    lookupResp = extractAddresses(lookupResp)
-    if (!Array.isArray(lookupResp) || lookupResp.length < 1) throw new Error(`fallback to dnsLookup returned no address ${host}`)
-    ips = lookupResp
+    const lookupResp = await dnsLookup(host, { all: true }); // pass options all: true for all addresses
+    const addresses = extractAddresses(lookupResp);
+    if (!Array.isArray(addresses) || addresses.length < 1)
+      throw new Error(`fallback to dnsLookup returned no address ${host}`);
+    ips = addresses;
   }
-  return ips
+  return ips;
 }
 
 // dns.lookup
 // ***************** { address: '142.250.190.68', family: 4 }
 // , { all: true } /***************** [ { address: '142.250.190.68', family: 4 } ]
 
-function extractAddresses(lookupResp: any) {
-  if (!Array.isArray(lookupResp)) throw new Error('lookup response did not contain array of addresses')
-  return lookupResp.filter((e) => e.address != null).map((e) => e.address)
+function extractAddresses(lookupResp: dns.LookupAddress[]) {
+  if (!Array.isArray(lookupResp))
+    throw new Error("lookup response did not contain array of addresses");
+  return lookupResp.filter((e) => e.address != null).map((e) => e.address);
 }
 
-function recordError(err: any, errMesg: string) {
-  stats.errors += 1
-  stats.lastError = err
-  stats.lastErrorTs = Date.now()
-  log.error(err, errMesg)
+function recordError(err: unknown, errMesg: string) {
+  stats.errors += 1;
+  stats.lastError = err;
+  stats.lastErrorTs = Date.now();
+  log.error(err, errMesg);
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,21 @@
 import { AxiosInstance } from "axios";
-import LRUCache from "lru-cache";
+
+interface RedisConfig {
+  url: string;
+  password?: string;
+  ttl: number; // Redis TTL in seconds
+}
+
+interface CacheInterface {
+  size: number;
+  get(key: string): Promise<DnsEntry | null>;
+  set(key: string, value: DnsEntry): Promise<void>;
+  entries(): Promise<DnsEntry[]>;
+  purgeStale(): Promise<void>;
+  delete(key: string): Promise<void>;
+  clear(): Promise<void>;
+}
+
 export interface Config {
   disabled: boolean;
   dnsTtlMs: number;
@@ -8,10 +24,12 @@ export interface Config {
   backgroundScanMs: number;
   dnsCacheSize: number;
   logging: LoggingConfig;
-  cache?: LRUCache<string, DnsEntry>;
+  redisConfig?: RedisConfig;
+  lruCacheConfig?: LRUCacheConfig;
+  cache: CacheInterface | undefined;
 }
 
-export interface CacheConfig {
+export interface LRUCacheConfig {
   max: number;
   ttl: number;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,7 +8,7 @@ export interface Config {
   backgroundScanMs: number;
   dnsCacheSize: number;
   logging: LoggingConfig;
-  cache?: LRUCache<string, any>;
+  cache?: LRUCache<string, DnsEntry>;
 }
 
 export interface CacheConfig {
@@ -23,7 +23,7 @@ export interface Stats {
   misses: number;
   idleExpired: number;
   errors: number;
-  lastError: any;
+  lastError: unknown;
   lastErrorTs: number;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 export {
   config,
-  cacheConfig,
   stats,
   init,
   reset,
@@ -12,4 +11,3 @@ export {
   getAddress,
   backgroundRefresh,
 } from "./axios-cached-dns-resolve";
-


### PR DESCRIPTION
The current implementation uses the `lru-cache` npm package which can be limiting.

This PR adds the ability to use an external Redis cache 

Here's a video explanation: https://www.loom.com/share/77bb2e3df05e4e089f345c1d009c700e

## Testing

To test, confirm that the unit tests pass as they've been updated to run in both `lru-cache` and `redis` mode

Video of tests passing - https://www.loom.com/share/24010c0b96464591b9a814598b43d593