### PR TITLE
4.0.0 (BREAKING): Custom configuration + Environment variables prefix change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.0.0] - 2024-05-21
+
+### **Breaking Changes**
+
+- Changed environment/config variables to use `AXIOS_DNS_CACHE` prefix
+- Changed `init` function to allow for custom config
+
 ## [3.4.0] - 2024-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Use axiosClient as normal
 ## Configuration
 
 ```javascript
-const config = {
-  disabled: process.env.AXIOS_DNS_DISABLE === "true",
+export const config = {
+  disabled: process.env.AXIOS_DNS_CACHE_DISABLE === "true",
   dnsTtlMs: parseInt(process.env.AXIOS_DNS_CACHE_TTL_MS || "5000"), // when to refresh actively used dns entries (5 sec)
   cacheGraceExpireMultiplier: parseInt(
     process.env.AXIOS_DNS_CACHE_EXPIRE_MULTIPLIER || "2"
@@ -70,14 +70,14 @@ const config = {
   dnsIdleTtlMs:
     parseInt(process.env.AXIOS_DNS_CACHE_IDLE_TTL_MS || "1000") * 60 * 60, // when to remove entry entirely if not being used (1 hour)
   backgroundScanMs: parseInt(
-    process.env.AXIOS_DNS_BACKGROUND_SCAN_MS || "2400"
+    process.env.AXIOS_DNS_CACHE_BACKGROUND_SCAN_MS || "2400"
   ), // how frequently to scan for expired TTL and refresh (2.4 sec)
   dnsCacheSize: parseInt(process.env.AXIOS_DNS_CACHE_SIZE || "100"), // maximum number of entries to keep in cache
   // pino logging options
   logging: {
     name: "axios-cache-dns-resolve",
     // enabled: true,
-    level: process.env.AXIOS_DNS_LOG_LEVEL || "info", // default 'info' others trace, debug, info, warn, error, and fatal
+    level: process.env.AXIOS_DNS_CACHE_LOG_LEVEL || "info", // default 'info' others trace, debug, info, warn, error, and fatal
     // timestamp: true,
     prettyPrint: process.env.NODE_ENV === "DEBUG" || false,
     formatters: {
@@ -87,11 +87,11 @@ const config = {
     },
   },
   redisConfig:
-    process.env.USE_REDIS === "true"
+    process.env.AXIOS_DNS_CACHE_USE_REDIS === "true"
       ? {
-          url: process.env.REDIS_URL || "localhost:6379",
-          password: process.env.REDIS_PASSWORD,
-          ttl: parseInt(process.env.REDIS_TTL || "5"), // default 5 seconds
+          url: process.env.AXIOS_DNS_CACHE_REDIS_URL || "localhost:6379",
+          password: process.env.AXIOS_DNS_CACHE_REDIS_PASSWORD,
+          ttl: parseInt(process.env.AXIOS_DNS_CACHE_REDIS_TTL || "5"), // default 5 seconds
         }
       : undefined,
   cache: undefined as LRUCache<string, DnsEntry> | undefined,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cryptotaxcalculator/axios-cached-dns-resolve",
-  "version": "3.4.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cryptotaxcalculator/axios-cached-dns-resolve",
-      "version": "3.4.0",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "ioredis": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cryptotaxcalculator/axios-cached-dns-resolve",
-  "version": "3.4.0",
+  "version": "4.0.0",
   "files": [
     "dist"
   ],

--- a/src/DNSEntryCache.ts
+++ b/src/DNSEntryCache.ts
@@ -26,8 +26,8 @@ export class DNSEntryCache implements CacheInterface {
     } else {
       // Default to LRU cache
       this.lruCache = new LRUCache<string, DnsEntry>({
-        max: 500,
-        ttl: 1000,
+        max: 100,
+        ttl: 10000,
       });
     }
   }

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -2,6 +2,7 @@ import axios, { AxiosInstance } from "axios";
 import delay from "delay";
 import * as axiosCachingDns from "..";
 import { DNSEntryCache } from "../DNSEntryCache";
+import { Config } from "../index.d";
 
 let axiosClient: AxiosInstance;
 let useRedis: boolean = false; // Flag to switch between Redis and LRU
@@ -49,6 +50,35 @@ beforeEach(async () => {
 afterAll(() => {
   axiosCachingDns.config.cache?.clear();
   axiosCachingDns.reset();
+});
+
+describe("Initialization Tests", () => {
+  test("init function with custom config", async () => {
+    const customConfig = {
+      disabled: false,
+      dnsTtlMs: 3000,
+      cacheGraceExpireMultiplier: 3,
+      dnsIdleTtlMs: 2000,
+      backgroundScanMs: 1500,
+      dnsCacheSize: 50,
+      logging: {
+        name: "test-logger",
+        level: "debug",
+        prettyPrint: true,
+        formatters: {
+          level: (label: string) => ({ level: label }),
+        },
+      },
+      redisConfig: undefined,
+      lruCacheConfig: {
+        max: 50,
+        ttl: 9000,
+      },
+    } as Config;
+
+    axiosCachingDns.init(customConfig);
+    expect(axiosCachingDns.config).toEqual(customConfig);
+  });
 });
 
 describe("LRU Cache Tests", () => {

--- a/src/axios-cached-dns-resolve.ts
+++ b/src/axios-cached-dns-resolve.ts
@@ -12,8 +12,8 @@ import { init as initLogger } from "./logging";
 const dnsResolve = util.promisify(dns.resolve);
 const dnsLookup = util.promisify(dns.lookup);
 
-export const config = {
-  disabled: process.env.AXIOS_DNS_DISABLE === "true",
+export let config = {
+  disabled: process.env.AXIOS_DNS_CACHE_DISABLE === "true",
   dnsTtlMs: parseInt(process.env.AXIOS_DNS_CACHE_TTL_MS || "5000"), // when to refresh actively used dns entries (5 sec)
   cacheGraceExpireMultiplier: parseInt(
     process.env.AXIOS_DNS_CACHE_EXPIRE_MULTIPLIER || "2"
@@ -21,14 +21,14 @@ export const config = {
   dnsIdleTtlMs:
     parseInt(process.env.AXIOS_DNS_CACHE_IDLE_TTL_MS || "1000") * 60 * 60, // when to remove entry entirely if not being used (1 hour)
   backgroundScanMs: parseInt(
-    process.env.AXIOS_DNS_BACKGROUND_SCAN_MS || "2400"
+    process.env.AXIOS_DNS_CACHE_BACKGROUND_SCAN_MS || "2400"
   ), // how frequently to scan for expired TTL and refresh (2.4 sec)
   dnsCacheSize: parseInt(process.env.AXIOS_DNS_CACHE_SIZE || "100"), // maximum number of entries to keep in cache
   // pino logging options
   logging: {
     name: "axios-cache-dns-resolve",
     // enabled: true,
-    level: process.env.AXIOS_DNS_LOG_LEVEL || "info", // default 'info' others trace, debug, info, warn, error, and fatal
+    level: process.env.AXIOS_DNS_CACHE_LOG_LEVEL || "info", // default 'info' others trace, debug, info, warn, error, and fatal
     // timestamp: true,
     prettyPrint: process.env.NODE_ENV === "DEBUG" || false,
     formatters: {
@@ -38,11 +38,11 @@ export const config = {
     },
   },
   redisConfig:
-    process.env.USE_REDIS === "true"
+    process.env.AXIOS_DNS_CACHE_USE_REDIS === "true"
       ? {
-          url: process.env.REDIS_URL || "localhost:6379",
-          password: process.env.REDIS_PASSWORD,
-          ttl: parseInt(process.env.REDIS_TTL || "5"), // default 5 seconds
+          url: process.env.AXIOS_DNS_CACHE_REDIS_URL || "localhost:6379",
+          password: process.env.AXIOS_DNS_CACHE_REDIS_PASSWORD,
+          ttl: parseInt(process.env.AXIOS_DNS_CACHE_REDIS_TTL || "5"), // default 5 seconds
         }
       : undefined,
   cache: undefined as LRUCache<string, DnsEntry> | undefined,
@@ -70,7 +70,8 @@ let cachePruneId: NodeJS.Timeout;
 
 init();
 
-export function init() {
+export function init(customConfig?: Config) {
+  config = customConfig || config;
   log = initLogger(config.logging);
 
   if (config.cache) return;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -64,13 +64,13 @@ export interface DnsEntry {
 }
 
 declare module "axios-cached-dns-resolve" {
-  export function init(config?: Config): void;
-  export function startBackgroundRefresh(): void;
-  export function startPeriodicCachePrune(): void;
+  export async function init(config?: Config): Promise<void>;
+  export async function startBackgroundRefresh(): Promise<void>;
+  export async function startPeriodicCachePrune(): Promise<void>;
   export function getStats(): Stats;
-  export function getDnsCacheEntries(): DnsEntry[];
+  export async function getDnsCacheEntries(): Promise<DnsEntry[]>;
   export function registerInterceptor(axios: AxiosInstance): void;
-  export function getAddress(host: string): Promise<string>;
-  export function backgroundRefresh(): Promise<void>;
-  export function resolve(host: string): Promise<string[]>;
+  export async function getAddress(host: string): Promise<string>;
+  export async function backgroundRefresh(): Promise<void>;
+  export async function resolve(host: string): Promise<string[]>;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -48,7 +48,8 @@ export interface Stats {
 interface LoggingConfig {
   name: string;
   level: string;
-  prettyPrint: boolean;
+  prettyPrint?: boolean;
+  stream?: NodeJS.WritableStream;
   formatters: {
     level: (label: string) => { level: string };
   };
@@ -63,7 +64,7 @@ export interface DnsEntry {
 }
 
 declare module "axios-cached-dns-resolve" {
-  export function init(): void;
+  export function init(config?: Config): void;
   export function startBackgroundRefresh(): void;
   export function startPeriodicCachePrune(): void;
   export function getStats(): Stats;

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,11 +1,19 @@
-import pino, { Logger } from 'pino'
+import pino, { Logger } from "pino";
+import pretty from "pino-pretty";
+import { LoggingConfig } from "./index.d";
 
-let logger: Logger
+let logger: Logger;
 
-export function init(options: pino.LoggerOptions) {
-  return (logger = pino(options))
+export function init(options: LoggingConfig) {
+  if (options.prettyPrint) {
+    const prettyOptions = pretty({ colorize: true });
+    options.stream = prettyOptions;
+    delete options.prettyPrint; // Remove unsupported option
+  }
+
+  return (logger = pino(options));
 }
 
 export function getLogger() {
-  return logger
+  return logger;
 }


### PR DESCRIPTION
## Summary
This PR adds the AXIOS_DNS_CACHE_ prefix to environment variables (to prevent conflicts between existing variables like REDIS_URL in the user's codebase)

It also allows for a custom config to be set in case the user doesn't want to use environment variables to set the config

## Testing
A new unit test has been added to test the ability to set a custom configuration.

Simply verify all unit tests pass to test this change

<img width="734" alt="image" src="https://github.com/cryptotaxcalculator/axios-cached-dns-resolve/assets/80376634/6a40bc2c-3d03-4e7c-bb9c-996b29529626">
